### PR TITLE
Abandon session when deleting account to have similar behavior as pressing "End visit" in Demo feature

### DIFF
--- a/src/Feature/Accounts/code/Controllers/AccountsController.cs
+++ b/src/Feature/Accounts/code/Controllers/AccountsController.cs
@@ -364,6 +364,7 @@ namespace Sitecore.HabitatHome.Feature.Accounts.Controllers
 
                 if (Context.User.Profile.Email != null)
                 {
+                    this.Session.Abandon();
                     _userProfileService.DeleteProfile(Context.User.Profile);
                     _accountRepository.Logout();
                 }

--- a/src/Feature/Accounts/code/Controllers/AccountsController.cs
+++ b/src/Feature/Accounts/code/Controllers/AccountsController.cs
@@ -364,7 +364,7 @@ namespace Sitecore.HabitatHome.Feature.Accounts.Controllers
 
                 if (Context.User.Profile.Email != null)
                 {
-
+                    this.Session.Abandon();
                     _userProfileService.DeleteProfile(Context.User.Profile);
                     _accountRepository.Logout();
                 }

--- a/src/Feature/Accounts/code/Controllers/AccountsController.cs
+++ b/src/Feature/Accounts/code/Controllers/AccountsController.cs
@@ -364,7 +364,7 @@ namespace Sitecore.HabitatHome.Feature.Accounts.Controllers
 
                 if (Context.User.Profile.Email != null)
                 {
-                    this.Session.Abandon();
+
                     _userProfileService.DeleteProfile(Context.User.Profile);
                     _accountRepository.Logout();
                 }


### PR DESCRIPTION
Abandon session when deleting account to have similar behavior as pressing "End visit" in Demo feature

Resolves Sitecore/Sitecore.HabitatHome.Platform#71