### PR TITLE
Fix for Unicorn Sync dependency of Habitat Home Basic on Habitat Home

### DIFF
--- a/src/Project/Common/code/App_Config/Include/Project/Common.Website.Serialization.config
+++ b/src/Project/Common/code/App_Config/Include/Project/Common.Website.Serialization.config
@@ -3,7 +3,7 @@
   <sitecore unicorn:require="On">
     <unicorn>
       <configurations>
-        <configuration name="Project.Common.Website" description="Includes the root tenant folder." dependencies="Foundation.*,Feature.*,Project.Common" extends="Helix.Project">
+        <configuration name="Project.Common.Website" description="Includes the root tenant folder." dependencies="Foundation.*,Feature.*" extends="Helix.Project">
           <predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
 
             <include name="Project.Templates" database="master" path="/sitecore/templates/Project/Habitat Sites">

--- a/src/Project/Habitat/code/App_Config/Include/Project/Habitat.Website.Serialization.config
+++ b/src/Project/Habitat/code/App_Config/Include/Project/Habitat.Website.Serialization.config
@@ -3,7 +3,7 @@
     <sitecore unicorn:require="On">
         <unicorn>
             <configurations>
-                <configuration name="Project.Habitat.Website" description="Habitat content" dependencies="Foundation.*,Feature.*,Project.Common" extends="Helix.Base">
+                <configuration name="Project.Habitat.Website" description="Habitat content" dependencies="Foundation.*,Feature.*,Project.Common.Website" extends="Helix.Base">
                     <predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
                         <include name="Templates" database="master" path="/sitecore/templates/Project/Habitat Sites/Habitat" />
                         <include name="Templates.Branches" database="master" path="/sitecore/templates/Branches/Project/Habitat Sites/Habitat" />

--- a/src/Project/HabitatHomeBasic/code/App_Config/Include/Project/HabitatHome.Basic.Website.Serialization.config
+++ b/src/Project/HabitatHomeBasic/code/App_Config/Include/Project/HabitatHome.Basic.Website.Serialization.config
@@ -3,7 +3,7 @@
     <sitecore unicorn:require="On">
         <unicorn>
             <configurations>
-                <configuration name="Project.HabitatHome.Basic.Website" description="Habitat Home Basic content" dependencies="Foundation.*,Feature.*,Project.Common.Website,Project.Habitat.Website">
+                <configuration name="Project.HabitatHome.Basic.Website" description="Habitat Home Basic content" dependencies="Foundation.*,Feature.*,Project.Common.Website,Project.Habitat.Website,Project.HabitatHome.Website">
                     <targetDataStore physicalRootPath="$(sourceFolder)\Project\HabitatHomeBasic\serialization" useDataCache="false" singleInstance="true" />
                     <predicate type="Unicorn.Predicates.SerializationPresetPredicate, Unicorn" singleInstance="true">
                         <include name="Content" database="master" path="/sitecore/content/Habitat Sites/Habitat Home Basic" />


### PR DESCRIPTION
On a clean install, the Sync-Unicorn tasks would fail when syncing Habitat Home Basic because of a missing dependency on the Habitat Home Unicorn serialization config
