### PR TITLE
fixing missing icons on the trainer finder form

### DIFF
--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Aerobics.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Aerobics.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Aerobics
+  Value: aerobics
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Cardio.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Cardio.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Cardio
+  Value: cardio
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Strength.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Strength.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Strength
+  Value: strength
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Weight Lifting.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Weight Lifting.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Weight Lifting
+  Value: "weight-lifting"
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Yoga.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 1/Yoga.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Yoga
+  Value: yoga
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 2/1-2 days.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 2/1-2 days.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: "1-2 days"
+  Value: "one-two-days"
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 2/3-4 days.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 2/3-4 days.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: "3-4 days"
+  Value: "three-four-days"
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 2/5 or more days.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 2/5 or more days.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: 5 or more
+  Value: "five-or-more"
 Languages:
 - Language: en
   Versions:

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 3/High.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 3/High.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: High
+  Value: high
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 3/Low.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 3/Low.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Low
+  Value: low
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 3/Medium.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Data/Forms/Form Content Tokens/Trainer Finder/question 3/Medium.yml
@@ -7,7 +7,7 @@ DB: master
 SharedFields:
 - ID: "02f6fb63-fe92-44e8-afa2-20747c893502"
   Hint: Key
-  Value: Medium
+  Value: medium
 - ID: "b0a67b2a-8b07-4e0b-8809-69f751709806"
   Hint: __Tracking
   Type: Tracking

--- a/src/Project/HabitatHome/serialization/Content/Habitat Home/Home/habitat-health/trainer-finder/recommendations.yml
+++ b/src/Project/HabitatHome/serialization/Content/Habitat Home/Home/habitat-health/trainer-finder/recommendations.yml
@@ -20,7 +20,7 @@ SharedFields:
           uid="{BE983549-B92F-493D-9EDE-1BCDF7AF68BB}"
           p:before="*"
           s:id="{C25766C8-9AFD-4D28-87FE-147774F6806D}"
-          s:par="SplitterSize=2&amp;EnabledPlaceholders=1,2&amp;Styles1&amp;Styles2&amp;Styles3&amp;Styles4&amp;Styles5&amp;Styles6&amp;Styles7&amp;Styles8&amp;ColumnWidth1={F6DC722E-15DB-4826-920B-ACCFDA772432}&amp;ColumnWidth2={F6DC722E-15DB-4826-920B-ACCFDA772432}&amp;ColumnWidth3&amp;ColumnWidth4&amp;ColumnWidth5&amp;ColumnWidth6&amp;ColumnWidth7&amp;ColumnWidth8&amp;Reset Caching Options&amp;DynamicPlaceholderId=17"
+          s:par="SplitterSize=2&amp;EnabledPlaceholders=1%2C2&amp;Styles1&amp;Styles2&amp;Styles3&amp;Styles4&amp;Styles5&amp;Styles6&amp;Styles7&amp;Styles8&amp;ColumnWidth1=%7B113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2%7D%7C%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D%7C%7B2040C827-8640-4E61-907E-D3D5A25696C3%7D%7C%7BF58A39D5-1B62-4A8A-95AD-65B3878BB873%7D&amp;ColumnWidth2=%7B113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2%7D%7C%7BF2FCE948-4F77-44AF-A188-B2030061F793%7D%7C%7B2040C827-8640-4E61-907E-D3D5A25696C3%7D%7C%7BF58A39D5-1B62-4A8A-95AD-65B3878BB873%7D&amp;ColumnWidth3&amp;ColumnWidth4&amp;ColumnWidth5&amp;ColumnWidth6&amp;ColumnWidth7&amp;ColumnWidth8&amp;Reset Caching Options&amp;DynamicPlaceholderId=17"
           s:ph="/main/sxa-content-container/container-1/container-24" />
         <r
           uid="{D0328E1C-2861-4E34-B9F1-DDCE73265D4A}"
@@ -114,14 +114,14 @@ SharedFields:
           p:after="r[@uid='{61F2DF92-920D-466E-A6A8-C588FFA5650F}']"
           s:ds="{6238B3BB-E9C4-4AFB-B445-BE302466691E}"
           s:id="{162AB463-0CE1-4295-8F7E-2E2E969984ED}"
-          s:par="GridParameters&amp;FieldNames={3E6E7D0C-2472-4157-B4C8-F920504A4196}&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=19"
+          s:par="GridParameters=%7B113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2%7D&amp;FieldNames=%7B3E6E7D0C-2472-4157-B4C8-F920504A4196%7D&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=19"
           s:ph="/main/sxa-content-container/container-1/container-24/column-2-17" />
         <r
           uid="{28CF031E-F7C3-4A3E-853D-D5CA1D13694C}"
           p:after="r[@uid='{FF1D3B84-DC47-4640-AD29-93CB187562C8}']"
           s:ds="{8A33684A-7711-4445-A119-BD1EFEC890B6}"
           s:id="{162AB463-0CE1-4295-8F7E-2E2E969984ED}"
-          s:par="GridParameters&amp;FieldNames={3E6E7D0C-2472-4157-B4C8-F920504A4196}&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=18"
+          s:par="GridParameters=%7B113BEF7C-97E6-46CA-8CF3-916F7FAA8DE2%7D&amp;FieldNames=%7B3E6E7D0C-2472-4157-B4C8-F920504A4196%7D&amp;Styles&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=18"
           s:ph="/main/sxa-content-container/container-1/container-24/column-1-17" />
         <r
           uid="{BC9CAC62-3D7F-4FEF-98E6-B20C904DE5D1}"
@@ -148,7 +148,7 @@ SharedFields:
           uid="{99858130-CF14-4B64-A5AB-7A0C9903C1DC}"
           p:after="*[1=2]"
           s:id="{896A2C68-1362-4E88-8BA0-1805AE6D4837}"
-          s:par="GridParameters&amp;BackgroundImage&amp;Styles={45645D8F-56A4-460A-B5FB-51709FEFCE52}|{3D258225-9410-4FAF-A516-43490258337D}&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=24"
+          s:par="GridParameters&amp;BackgroundImage&amp;Styles=%7BB32CF8A3-6E9B-4D8B-992C-91B8C667FFFA%7D%7C%7B9CB76B6C-2B77-4728-8508-CF7041C7B69C%7D&amp;Reset Caching Options&amp;RenderingIdentifier&amp;DynamicPlaceholderId=24"
           s:ph="/main/sxa-content-container/container-1" />
       </d>
     </r>

--- a/src/Project/HabitatHome/serialization/Forms/Forms/Trainer Finder Form.yml
+++ b/src/Project/HabitatHome/serialization/Forms/Forms/Trainer Finder Form.yml
@@ -18,7 +18,7 @@ SharedFields:
 - ID: "9eb86f19-2e5d-48db-9795-0ee4868eff11"
   Hint: Is Ajax
   Type: Checkbox
-  Value: 0
+  Value: 1
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder
   Value: 


### PR DESCRIPTION
The trainer finder form appeared to have its icons missing: the content token keys that fill out the form options/label classes were changed with the latest update, and the css no longer applied. 