### PR TITLE
'repAuthenticationApiKey' creation (requirements for SC 9.0.2 Scaled)

### DIFF
--- a/Azure/HelperScripts/Upload-Packages.ps1
+++ b/Azure/HelperScripts/Upload-Packages.ps1
@@ -903,6 +903,7 @@ if ($definstall -eq $true -and $topology -eq "single") {
 
     if ($config.Topology -eq "scaled") 
     {
+        $parameters.repAuthenticationApiKey.value = (New-Guid).ToString()    
         $parameters.cmMsDeployPackageUrl.value = $cmMsDeployPackageUrl
         $parameters.cdMsDeployPackageUrl.value = $cdMsDeployPackageUrl
         $parameters.cdMsDeployPackageUrl.value = $cdMsDeployPackageUrl


### PR DESCRIPTION
Sitecore requires 'repAuthenticationApiKey' but it was empty

add $parameters.repAuthenticationApiKey.value = (New-Guid).ToString()

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Have you lint your code locally prior to submission?
2. [ ] Have you ensured an issue exists? If not, please create one.
### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

