### PR TITLE
Modifying GetTransformFiles to correctly not pick up files from bin and obj folder

### DIFF
--- a/CakeScripts/helper-methods.cake
+++ b/CakeScripts/helper-methods.cake
@@ -95,7 +95,7 @@ public void PublishProjects(string rootFolder, string publishRoot)
 
 public FilePathCollection GetTransformFiles(string rootFolder)
 {
-    Func<IFileSystemInfo, bool> exclude_obj_bin_folder =fileSystemInfo => !fileSystemInfo.Path.FullPath.Contains("/obj/") || !fileSystemInfo.Path.FullPath.Contains("/bin/");
+    Func<IFileSystemInfo, bool> exclude_obj_bin_folder =fileSystemInfo => !fileSystemInfo.Path.FullPath.Contains("/obj/") && !fileSystemInfo.Path.FullPath.Contains("/bin/");
 
     var xdtFiles = GetFiles($"{rootFolder}\\**\\*.xdt", exclude_obj_bin_folder);
 


### PR DESCRIPTION
Right now the filter for /bin/ and /obj/ transform files is using this predicate:
` Func<IFileSystemInfo, bool> exclude_obj_bin_folder =fileSystemInfo => !fileSystemInfo.Path.FullPath.Contains("/obj/") || !fileSystemInfo.Path.FullPath.Contains("/bin/");`

This predicate always evaluates to true because if the file path is in obj - it is not in bin and vice versa.

The fix modifies the predicate to:

`  Func<IFileSystemInfo, bool> exclude_obj_bin_folder =fileSystemInfo => !fileSystemInfo.Path.FullPath.Contains("/obj/") && !fileSystemInfo.Path.FullPath.Contains("/bin/");`

So it picks files if they are not in obj and not in bin.
